### PR TITLE
Send zookeeper logs to standard out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,7 @@ RUN \
 
     # Remove build-time dependencies
     && apt-get purge -y --auto-remove $BUILD_DEPS \
-    && rm -rf /var/lib/apt/lists/* \
-
-    # Send zk output to stdout
-    && ln -sf /dev/stdout /opt/zookeeper/zookeeper.out
+    && rm -rf /var/lib/apt/lists/*
 
 # Add the wrapper script to setup configs and exec exhibitor
 ADD include/wrapper.sh /opt/exhibitor/wrapper.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN \
 
     # Remove build-time dependencies
     && apt-get purge -y --auto-remove $BUILD_DEPS \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+
+    # Send zk output to stdout
+    && ln -sf /dev/stdout /opt/zookeeper/zookeeper.out
 
 # Add the wrapper script to setup configs and exec exhibitor
 ADD include/wrapper.sh /opt/exhibitor/wrapper.sh
@@ -44,3 +47,4 @@ WORKDIR /opt/exhibitor
 EXPOSE 2181 2888 3888 8181
 
 ENTRYPOINT ["bash", "-ex", "/opt/exhibitor/wrapper.sh"]
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The container expects the following environment variables to be passed in:
 * `ZK_PASSWORD` - (optional) the HTTP Basic Auth password for the "zk" user
 * `ZK_DATA_DIR` - (optional) Zookeeper data directory
 * `ZK_LOG_DIR` - (optional) Zookeeper log directory
-* `ZK_LOG_TO_STDOUT` - (optional) Send zookeeper logs to stdout to be captured by docker logs
+* `ZK_LOG_TO_STDOUT` - (optional) Set to "true" to send zookeeper logs to stdout to be captured by docker logs
 * `HTTP_PROXY_HOST` - (optional) HTTP Proxy hostname
 * `HTTP_PROXY_PORT` - (optional) HTTP Proxy port
 * `HTTP_PROXY_USERNAME` - (optional) HTTP Proxy username

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The container expects the following environment variables to be passed in:
 * `ZK_PASSWORD` - (optional) the HTTP Basic Auth password for the "zk" user
 * `ZK_DATA_DIR` - (optional) Zookeeper data directory
 * `ZK_LOG_DIR` - (optional) Zookeeper log directory
+* `ZK_LOG_TO_STDOUT` - (optional) Send zookeeper logs to stdout to be captured by docker logs
 * `HTTP_PROXY_HOST` - (optional) HTTP Proxy hostname
 * `HTTP_PROXY_PORT` - (optional) HTTP Proxy port
 * `HTTP_PROXY_USERNAME` - (optional) HTTP Proxy username

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -39,7 +39,6 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE
 EOF
 
-
 if [[ -n ${AWS_ACCESS_KEY_ID} ]]; then
   cat <<- EOF > /opt/exhibitor/credentials.properties
     com.netflix.exhibitor.s3.access-key-id=${AWS_ACCESS_KEY_ID}
@@ -86,6 +85,10 @@ exec 2>&1
 # 	--configtype s3 --s3config thefactory-exhibitor:${CLUSTER_ID} \
 # 	--s3credentials /opt/exhibitor/credentials.properties \
 # 	--s3region us-west-2 --s3backup true
+
+if [[ ${ZK_LOG_TO_STDOUT} = "true" ]]; then
+  ln -sf /dev/stdout /opt/zookeeper/zookeeper.out
+fi
 
 java -jar /opt/exhibitor/exhibitor.jar \
   --port 8181 --defaultconfig /opt/exhibitor/defaults.conf \


### PR DESCRIPTION
Redirecting zookeeper output to stdout to make it easier to monitor with standard docker tools.
