### PR TITLE
Enable Auto Purge behavior of Zookeeper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:7.8
-MAINTAINER mweliczko
+MAINTAINER Mike Babineau michael.babineau@gmail.com
 
 ENV \
     ZK_RELEASE="http://www.apache.org/dist/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:7.8
 MAINTAINER mweliczko
 
 ENV \
-    ZK_RELEASE="http://www.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz" \
+    ZK_RELEASE="http://www.apache.org/dist/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz" \
     EXHIBITOR_POM="https://raw.githubusercontent.com/Netflix/exhibitor/d911a16d704bbe790d84bbacc655ef050c1f5806/exhibitor-standalone/src/main/resources/buildscripts/standalone/maven/pom.xml" \
     # Append "+" to ensure the package doesn't get purged
     BUILD_DEPS="curl maven openjdk-7-jdk+" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:7.8
-MAINTAINER Mike Babineau michael.babineau@gmail.com
+MAINTAINER mweliczko
 
 ENV \
     ZK_RELEASE="http://www.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,25 +12,32 @@ ENV \
 RUN \
     # Install dependencies
     apt-get update \
-    && apt-get install -y --allow-unauthenticated --no-install-recommends $BUILD_DEPS \
+    && apt-get install -y --allow-unauthenticated --no-install-recommends $BUILD_DEPS
 
     # Default DNS cache TTL is -1. DNS records, like, change, man.
-    && grep '^networkaddress.cache.ttl=' /etc/java-7-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-7-openjdk/security/java.security \
+RUN \
+	grep '^networkaddress.cache.ttl=' /etc/java-7-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-7-openjdk/security/java.security
 
     # Install ZK
-    && curl -Lo /tmp/zookeeper.tgz $ZK_RELEASE \
+
+RUN \
+	curl -Lo /tmp/zookeeper.tgz $ZK_RELEASE \
     && mkdir -p /opt/zookeeper/transactions /opt/zookeeper/snapshots \
     && tar -xzf /tmp/zookeeper.tgz -C /opt/zookeeper --strip=1 \
-    && rm /tmp/zookeeper.tgz \
+    && rm /tmp/zookeeper.tgz
 
     # Install Exhibitor
-    && mkdir -p /opt/exhibitor \
+
+RUN \
+	mkdir -p /opt/exhibitor \
     && curl -Lo /opt/exhibitor/pom.xml $EXHIBITOR_POM \
     && mvn -f /opt/exhibitor/pom.xml package \
-    && ln -s /opt/exhibitor/target/exhibitor*jar /opt/exhibitor/exhibitor.jar \
+    && ln -s /opt/exhibitor/target/exhibitor*jar /opt/exhibitor/exhibitor.jar
 
     # Remove build-time dependencies
-    && apt-get purge -y --auto-remove $BUILD_DEPS \
+
+RUN \
+	apt-get purge -y --auto-remove $BUILD_DEPS \
     && rm -rf /var/lib/apt/lists/*
 
 # Add the wrapper script to setup configs and exec exhibitor

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,32 +12,25 @@ ENV \
 RUN \
     # Install dependencies
     apt-get update \
-    && apt-get install -y --allow-unauthenticated --no-install-recommends $BUILD_DEPS
+    && apt-get install -y --allow-unauthenticated --no-install-recommends $BUILD_DEPS \
 
     # Default DNS cache TTL is -1. DNS records, like, change, man.
-RUN \
-	grep '^networkaddress.cache.ttl=' /etc/java-7-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-7-openjdk/security/java.security
+    && grep '^networkaddress.cache.ttl=' /etc/java-7-openjdk/security/java.security || echo 'networkaddress.cache.ttl=60' >> /etc/java-7-openjdk/security/java.security \
 
     # Install ZK
-
-RUN \
-	curl -Lo /tmp/zookeeper.tgz $ZK_RELEASE \
+    && curl -Lo /tmp/zookeeper.tgz $ZK_RELEASE \
     && mkdir -p /opt/zookeeper/transactions /opt/zookeeper/snapshots \
     && tar -xzf /tmp/zookeeper.tgz -C /opt/zookeeper --strip=1 \
-    && rm /tmp/zookeeper.tgz
+    && rm /tmp/zookeeper.tgz \
 
     # Install Exhibitor
-
-RUN \
-	mkdir -p /opt/exhibitor \
+    && mkdir -p /opt/exhibitor \
     && curl -Lo /opt/exhibitor/pom.xml $EXHIBITOR_POM \
     && mvn -f /opt/exhibitor/pom.xml package \
-    && ln -s /opt/exhibitor/target/exhibitor*jar /opt/exhibitor/exhibitor.jar
+    && ln -s /opt/exhibitor/target/exhibitor*jar /opt/exhibitor/exhibitor.jar \
 
     # Remove build-time dependencies
-
-RUN \
-	apt-get purge -y --auto-remove $BUILD_DEPS \
+    && apt-get purge -y --auto-remove $BUILD_DEPS \
     && rm -rf /var/lib/apt/lists/*
 
 # Add the wrapper script to setup configs and exec exhibitor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Available on the Docker Index as [mbabineau/zookeeper-exhibitor](https://index.d
 
 ### Versions
 * Exhibitor 1.5.5
-* ZooKeeper 3.4.6
+* ZooKeeper 3.4.7
 
 ### Usage
 The container expects the following environment variables to be passed in:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The container expects the following environment variables to be passed in:
 * `ZK_PASSWORD` - (optional) the HTTP Basic Auth password for the "zk" user
 * `ZK_DATA_DIR` - (optional) Zookeeper data directory
 * `ZK_LOG_DIR` - (optional) Zookeeper log directory
+* `ZK_AUTOPURGE_PURGEINTERVAL` - (optional) The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging. Defaults to 0.
+* `ZK_AUTOPURGE_SNAPRETAINCOUNT` - (optional) When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir respectively and deletes the rest. Defaults to 3. Minimum value is 3.
 * `HTTP_PROXY_HOST` - (optional) HTTP Proxy hostname
 * `HTTP_PROXY_PORT` - (optional) HTTP Proxy port
 * `HTTP_PROXY_USERNAME` - (optional) HTTP Proxy username

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -33,7 +33,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=5&autopurge.purgeInterval\=24
+	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=5&autopurge.purgeInterval\=1
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -7,6 +7,8 @@ DEFAULT_AWS_REGION="us-west-2"
 DEFAULT_DATA_DIR="/opt/zookeeper/snapshots"
 DEFAULT_LOG_DIR="/opt/zookeeper/transactions"
 DEFAULT_ZK_ENSEMBLE_SIZE=0
+DEFAULT_AUTOPURGE_SNAPRETAINCOUNT="3"
+DEFAULT_AUTOPURGE_PURGEINTERVAL="0"
 S3_SECURITY=""
 HTTP_PROXY=""
 : ${HOSTNAME:?$MISSING_VAR_MESSAGE}
@@ -18,6 +20,8 @@ HTTP_PROXY=""
 : ${HTTP_PROXY_PORT:=""}
 : ${HTTP_PROXY_USERNAME:=""}
 : ${HTTP_PROXY_PASSWORD:=""}
+: ${AUTOPURGE_SNAPRETAINCOUNT:=$DEFAULT_AUTOPURGE_SNAPRETAINCOUNT}
+: ${AUTOPURGE_PURGEINTERVAL:=$DEFAULT_AUTOPURGE_PURGEINTERVAL}
 
 cat <<- EOF > /opt/exhibitor/defaults.conf
 	zookeeper-data-directory=$ZK_DATA_DIR
@@ -33,7 +37,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=5&autopurge.purgeInterval\=1
+	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -7,8 +7,8 @@ DEFAULT_AWS_REGION="us-west-2"
 DEFAULT_DATA_DIR="/opt/zookeeper/snapshots"
 DEFAULT_LOG_DIR="/opt/zookeeper/transactions"
 DEFAULT_ZK_ENSEMBLE_SIZE=0
-DEFAULT_AUTOPURGE_SNAPRETAINCOUNT="3"
-DEFAULT_AUTOPURGE_PURGEINTERVAL="0"
+DEFAULT_ZK_AUTOPURGE_SNAPRETAINCOUNT="3"
+DEFAULT_ZK_AUTOPURGE_PURGEINTERVAL="0"
 S3_SECURITY=""
 HTTP_PROXY=""
 : ${HOSTNAME:?$MISSING_VAR_MESSAGE}
@@ -20,8 +20,8 @@ HTTP_PROXY=""
 : ${HTTP_PROXY_PORT:=""}
 : ${HTTP_PROXY_USERNAME:=""}
 : ${HTTP_PROXY_PASSWORD:=""}
-: ${AUTOPURGE_SNAPRETAINCOUNT:=$DEFAULT_AUTOPURGE_SNAPRETAINCOUNT}
-: ${AUTOPURGE_PURGEINTERVAL:=$DEFAULT_AUTOPURGE_PURGEINTERVAL}
+: ${ZK_AUTOPURGE_SNAPRETAINCOUNT:=$DEFAULT_AUTOPURGE_SNAPRETAINCOUNT}
+: ${ZK_AUTOPURGE_PURGEINTERVAL:=$DEFAULT_AUTOPURGE_PURGEINTERVAL}
 
 cat <<- EOF > /opt/exhibitor/defaults.conf
 	zookeeper-data-directory=$ZK_DATA_DIR
@@ -37,7 +37,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
+	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$ZK_AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$ZK_AUTOPURGE_PURGEINTERVAL
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -37,7 +37,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2001&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
+	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -33,7 +33,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true
+	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=5&autopurge.purgeInterval\=24
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE

--- a/include/wrapper.sh
+++ b/include/wrapper.sh
@@ -37,7 +37,7 @@ cat <<- EOF > /opt/exhibitor/defaults.conf
 	connect-port=2888
 	observer-threshold=0
 	election-port=3888
-	zoo-cfg-extra=tickTime\=2000&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
+	zoo-cfg-extra=tickTime\=2001&initLimit\=10&syncLimit\=5&quorumListenOnAllIPs\=true&autopurge.snapRetainCount\=$AUTOPURGE_SNAPRETAINCOUNT&autopurge.purgeInterval\=$AUTOPURGE_PURGEINTERVAL
 	auto-manage-instances-settling-period-ms=0
 	auto-manage-instances=1
 	auto-manage-instances-fixed-ensemble-size=$ZK_ENSEMBLE_SIZE


### PR DESCRIPTION
Zookeeper 3.4.0 added two settings for automatically purging snapshots and transaction log files after a specified interval. I have found it necessary to use these settings to enable Zookeeper to stay running without running out of disk space.
